### PR TITLE
Automate wordpress installation and configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,35 @@ $ git clone https://github.com/wizeservices/vagrant-trusty-lemp [name-of-my-lemp
 * You can connect to your VM via SSH with `vagrant ssh`.
 * You can restart the VM with `vagrant reload` or stop it with `vagrant halt`.
 * If you're not gonna need the VM anymore and want to free the resources you can use `vagrant destroy`.
+* **Warning:** If you made any changes to the variables in puppet facter remember to delete the content of the mapped directory (rm -rf ./www/), if not
+the configuration won't be updated.
+
+## Puppet apply
+1. Login as root user:
+```
+sudo su
+```
+
+2. Install the puppet module for apt:
+```
+puppet module install puppetlabs/apt --target-dir ./puppet/modules
+```
+
+3. Create a file at /etc/facter/facts.d/custom.txt (**Note:** the wp_url must be in your /etc/hosts to be able to reach by domain name):
+```
+mysql_root_password=vagrant
+wwwroot=/var/www/app
+db_username=username
+db_password=toor
+db_name=database_name
+wp_url=url
+wp_title=title
+wp_user=username
+wp_password=password
+wp_email=example@example.com
+```
+
+4. Run the following command:
+```
+puppet apply --debug --verbose puppet/manifests/site.pp --modulepath puppet/modules
+```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,6 @@
 VAGRANTFILE_API_VERSION = "2"
 PROJECT_NAME = 'damdiram'
+DEST_FOLDER = '/var/www/app'
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
@@ -15,7 +16,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.customize ['modifyvm', :id, '--memory', '1024']
   end
 
-  config.vm.synced_folder 'www', '/www'
+  config.vm.synced_folder 'www', DEST_FOLDER
   config.vm.provision 'shell', inline: 'test -d /etc/puppet/modules/apt || puppet module install puppetlabs/apt'
   config.vm.provision 'puppet' do |puppet|
     puppet.manifests_path = 'puppet/manifests'
@@ -24,7 +25,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     puppet.options        = '--verbose --debug'
     puppet.facter         = {
       'mysql_root_password'  => 'vagrant',
-      'wwwroot'              => '/www'
+      'wwwroot'              => DEST_FOLDER,
+      'db_username'          => 'username',
+      'db_password'          => 'password',
+      'db_name'              => 'database_name',
+      'wp_url'               => "#{config.vm.hostname}.local",
+      'wp_title'             => PROJECT_NAME,
+      'wp_user'              => 'username',
+      'wp_password'          => 'password',
+      'wp_email'             => 'email@example.com'
     }
   end
 

--- a/puppet/manifests/site.pp
+++ b/puppet/manifests/site.pp
@@ -1,10 +1,24 @@
+exec { 'create-app-root':
+  command => "/bin/mkdir -p $::wwwroot",
+  before => Class['nginx', 'mariadb::install', 'php5-fpm', 'phpmyadmin', 'git::install'],
+}
+
 class { 'nginx': }
 class { 'mariadb::install': }
 class { 'php5-fpm': }
-class { 'phpmyadmin': }
+class { 'phpmyadmin':
+  require => Class['mariadb::install'],
+}
 class { 'git::install': }
 class { 'composer':
   command_name => 'composer',
-  target_dir   => '/usr/local/bin'
+  target_dir   => '/usr/local/bin',
+  require => Class['php5-fpm'],
 }
-class { 'wp-cli': }
+class { 'wp-cli':
+  require => Class['composer'],
+}
+
+class { 'postbuild':
+  require => Class['mariadb::install', 'wp-cli']
+}

--- a/puppet/manifests/site.pp
+++ b/puppet/manifests/site.pp
@@ -1,3 +1,8 @@
+exec { 'update-packages':
+  command => "/usr/bin/apt-get update -y",
+  before => Exec["create-app-root"],
+}
+
 exec { 'create-app-root':
   command => "/bin/mkdir -p $::wwwroot",
   before => Class['nginx', 'mariadb::install', 'php5-fpm', 'phpmyadmin', 'git::install'],

--- a/puppet/modules/mariadb/manifests/init.pp
+++ b/puppet/modules/mariadb/manifests/init.pp
@@ -1,32 +1,6 @@
 class mariadb::install {
-  include apt
-
-  apt::key { 'mariadb':
-    ensure => present,
-    id     => 'cbcb082a1bb943db',
-    server => 'hkp://keyserver.ubuntu.com:80',
-  }
-
-  apt::source { 'mariadb':
-    location    => 'http://sfo1.mirrors.digitalocean.com/mariadb/repo/10.0/ubuntu',
-    release     => 'trusty',
-    repos       => 'main',
-    include     => {
-      'src' => false,
-    },
-    require     => Apt::Key['mariadb'],
-  }
-
-  exec { 'update-apt':
-    path    => '/usr/bin',
-    unless  => 'dpkg -s mariadb-server-10.0',
-    command => 'apt-get update',
-    require => Apt::Source['mariadb'],
-  }
-
-  package { ['mariadb-server-10.0', 'mariadb-client-10.0']:
+  package { 'MariaDB-server':
     ensure  => installed,
-    require => Exec['update-apt'],
   }
 
   exec { 'set-mysql-root-password':
@@ -34,14 +8,14 @@ class mariadb::install {
     unless      => "mysqladmin -uroot -p${::mysql_root_password} status",
     refreshonly => true,
     command     => "mysqladmin -uroot password ${::mysql_root_password}",
-    subscribe   => Package['mariadb-server-10.0'],
+    subscribe   => Package['MariaDB-server'],
   }
 }
 
 class mariadb::php5-mysql {
   package { 'php5-mysql':
     ensure  => installed,
-    require => Package['php5-fpm', 'mariadb-server-10.0'],
+    require => Package['php5-fpm', 'MariaDB-server'],
     notify  => Service['php5-fpm'],
   }
 }

--- a/puppet/modules/php5-fpm/manifests/init.pp
+++ b/puppet/modules/php5-fpm/manifests/init.pp
@@ -16,6 +16,12 @@ class php5-fpm {
     require => Apt::Ppa['ppa:ondrej/php5-5.6'],
   }
 
+  exec { 'deleting-bad-characters':
+    command => "/bin/sed -i '/author/d' /etc/init/php5-fpm.conf",
+    before => Service['php5-fpm'],
+    require => Package['php5-fpm', 'php5-cli'],
+  }
+
   service { 'php5-fpm':
     ensure     => running,
     enable     => true,

--- a/puppet/modules/phpmyadmin/manifests/init.pp
+++ b/puppet/modules/phpmyadmin/manifests/init.pp
@@ -4,7 +4,7 @@ class phpmyadmin {
     require => Package['php5-fpm'],
   }
 
-  file { '/www/phpmyadmin':
+  file { "$::wwwroot/phpmyadmin":
     ensure  => 'link',
     target  => '/usr/share/phpmyadmin',
     require => Package['phpmyadmin'],

--- a/puppet/modules/postbuild/manifests/init.pp
+++ b/puppet/modules/postbuild/manifests/init.pp
@@ -1,0 +1,34 @@
+class postbuild {
+  $wp_bin = "/usr/bin/wp --allow-root"
+  exec { 'wp-download':
+    command => "$wp_bin core download",
+    cwd => $::wwwroot,
+    unless => '/bin/ls wp-content',
+  }
+
+  $content = "
+CREATE DATABASE $::db_name;
+CREATE USER $::db_username@localhost;
+GRANT ALL PRIVILEGES ON *.* TO '$::db_username'@'localhost' IDENTIFIED BY '$::db_password' WITH GRANT OPTION;
+FLUSH PRIVILEGES;
+"
+  exec { 'mysql-configuration':
+    path   => "/usr/bin:/usr/sbin:/bin",
+    command => "mysql -u root -pvagrant -e \"$content\"",
+    unless => "/usr/bin/mysql -u root -pvagrant -e 'show databases' | grep $::db_name",
+  }
+
+  exec { 'wp-configuration':
+    command => "$wp_bin core --path=$wp_path config --dbname=$::db_name --dbuser=$::db_username --dbpass=$::db_password",
+    require => Exec['mysql-configuration'],
+    unless => "/bin/ls wp-config.php",
+    cwd => $::wwwroot,
+  }
+
+  exec { 'wp-installation':
+    command => "$wp_bin core install --url=$::wp_url --title=$::wp_title --admin_user=$::wp_user --admin_password=$wp_password --admin_email=$wp_email --skip-email",
+    require => Exec['wp-configuration'],
+    cwd => $::wwwroot,
+    unless => "$wp_bin core is-installed"
+  }
+}

--- a/puppet/modules/wp-cli/manifests/init.pp
+++ b/puppet/modules/wp-cli/manifests/init.pp
@@ -9,12 +9,14 @@ class wp-cli {
   file { '/usr/bin/wp':
     ensure => 'link',
     target => '/usr/share/wp-cli/bin/wp',
+    require => Exec['composer-wp-cli'],
   }
 
   exec { 'wp-cli-fix-permissions':
     command => "chmod a+x /usr/share/wp-cli/bin/wp",
     path => '/usr/bin:/bin:/usr/sbin:/sbin',
     user => 'root',
+    require => Exec['composer-wp-cli'],
   }
 
 }


### PR DESCRIPTION
#### What does this PR do?

It automates wordpress installation and configuration. Also, fix some dependencies regarding the installation order.
#### Where should the reviewer start?
1. Clone the branch.
2. Change the project name and the puppet facter variables.
3. Install vagrant hostname plugin:  
   `
   vagrant plugin install vagrant-hostmanager
   `
4. Run the following command:  
   `
   vagrant up
   `
5. No errors should occur thanks to the addition of the dependency order. If it displays any error to you, please add it as a comment.
#### How should this be manually tested?
1. After running vagrant up, you should be able to ping to your domain <project_name>, run the following:  
   
   ```
   ping <project_name>
   ```
   
   1.1 If not, you have to manually add the entry for your domain in /etc/hosts.
2. After you are able to ping, go to your browser and open <project_name>/, it should render wordpress index page.
